### PR TITLE
fix(values): promote listenersets and tlsroutes to standard channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update `install.listenersets` value to `standard` (renamed from `xlistenersets`)
+- Update `install.tlsroutes` value to `standard`
+
 ## [1.8.0] - 2026-05-22
 
 - Upgrade Gateway API Inference Extension CRDs to [v1.4.0](https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/tag/v1.4.0)

--- a/helm/gateway-api-crds/values.schema.json
+++ b/helm/gateway-api-crds/values.schema.json
@@ -35,7 +35,7 @@
                 },
                 "tlsroutes": {
                     "type": "string",
-                    "enum": ["experimental", ""]
+                    "enum": ["standard", "experimental", ""]
                 },
                 "udproutes": {
                     "type": "string",
@@ -45,9 +45,9 @@
                     "type": "string",
                     "enum": ["experimental", ""]
                 },
-                "xlistenersets": {
+                "listenersets": {
                     "type": "string",
-                    "enum": ["experimental", ""]
+                    "enum": ["standard", "experimental", ""]
                 },
                 "xmeshes": {
                     "type": "string",
@@ -60,6 +60,9 @@
                 "inferenceobjectives": {
                     "type": "string",
                     "enum": ["experimental", ""]
+                },
+                "admissionPolicies": {
+                    "type": "boolean"
                 }
             }
         }

--- a/helm/gateway-api-crds/values.yaml
+++ b/helm/gateway-api-crds/values.yaml
@@ -11,17 +11,17 @@ install:
   referencegrants: standard
   # Supports "standard", "experimental" and "" (empty string to disable rendering this CRD)
   backendtlspolicies: standard
+  # Supports "standard", "experimental" and "" (empty string to disable rendering this CRD)
+  listenersets: "standard"
 
   # Supports "experimental" and "" (empty string to disable rendering this CRD)
   tcproutes: ""
-  # Supports "experimental" and "" (empty string to disable rendering this CRD)
-  tlsroutes: ""
+  # Supports "standard", "experimental" and "" (empty string to disable rendering this CRD)
+  tlsroutes: standard
   # Supports "experimental" and "" (empty string to disable rendering this CRD)
   udproutes: ""
   # Supports "experimental" and "" (empty string to disable rendering this CRD)
   xbackendtrafficpolicies: ""
-  # Supports "experimental" and "" (empty string to disable rendering this CRD)
-  xlistenersets: ""
   # Supports "experimental" and "" (empty string to disable rendering this CRD)
   xmeshes: ""
 


### PR DESCRIPTION
## Summary

- Rename `xlistenersets` → `listenersets` and set to `standard`, reflecting the v1.5.1 rename from the `x-k8s.io` experimental group to the stable `k8s.io` group
- Promote `tlsroutes` from `""` (disabled) to `standard`, now that a standard-channel CRD was added in v1.5.1
- Update comments for both entries to document the `"standard"` option

## Test plan

- [ ] Verify `helm template` renders both `listenersets` and `tlsroutes` CRDs from the standard channel
- [ ] Confirm no regressions for other CRD values